### PR TITLE
Preventing error "RuntimeError: CUDA error: out of memory"

### DIFF
--- a/neural_dream/CaffeLoader.py
+++ b/neural_dream/CaffeLoader.py
@@ -409,7 +409,7 @@ def add_classifier_layers(cnn, pooling='avg'):
 def loadCaffemodel(model_file, pooling, use_gpu, disable_check, add_classifier=False):
     cnn, layerList = modelSelector(str(model_file).lower(), pooling)
 
-    cnn.load_state_dict(torch.load(model_file), strict=(not disable_check))
+    cnn.load_state_dict(torch.load(model_file, map_location='cpu'), strict=(not disable_check))
     print("Successfully loaded " + str(model_file))
 
     # Maybe convert the model to cuda now, to avoid later issues


### PR DESCRIPTION
I have GPU, but it has not free memory. I tried run neural_dream on cpu and got error:
```
python3 neural_dream.py -content_image 1/0.png -output_image 1/14.png -model_file googlenet2.pth  -disable_check -model_type pytorch -dream_layers maxpool4 -learning_rate 0.001 -gpu c
GoogLeNet Architecture Detected
Traceback (most recent call last):
  File "neural_dream.py", line 793, in <module>
    main()
  File "neural_dream.py", line 121, in main
    cnn, layerList = loadCaffemodel(params.model_file, params.pooling, params.gpu, params.disable_check, True)
  File "/home/xxx/neural-dream/neural_dream/CaffeLoader.py", line 412, in loadCaffemodel
    cnn.load_state_dict(torch.load(model_file)['state_dict'], strict=(not disable_check))
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/serialization.py", line 529, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/serialization.py", line 702, in _legacy_load
    result = unpickler.load()
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/serialization.py", line 665, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/serialization.py", line 156, in default_restore_location
    result = fn(storage, location)
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/serialization.py", line 136, in _cuda_deserialize
    return storage_type(obj.size())
  File "/home/xxx/.local/lib/python3.7/site-packages/torch/cuda/__init__.py", line 480, in _lazy_new
    return super(_CudaBase, cls).__new__(cls, *args, **kwargs)
RuntimeError: CUDA error: out of memory
```

This patch fix it.